### PR TITLE
Feat/organize approved

### DIFF
--- a/.github/scripts/organize_approved.sh
+++ b/.github/scripts/organize_approved.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Define the directory to move files to
+destination="approved"
+
+# Create the directory if it doesn't exist
+mkdir -p "$destination"
+
+# Loop through all files in the current directory
+for file in *; do
+    # Check if the file is not one of the excluded files
+    if [ -f "$file" ] && [[ "$file" != "CONTRIBUTING.md" && "$file" != "CODE_OF_CONDUCT.md" && "$file" != "README.md" ]]; then
+        # Move the file to the destination directory
+        mv "$file" "$destination/"
+    fi
+done
+
+echo "Files moved successfully."

--- a/.github/workflows/organize_approved.yaml
+++ b/.github/workflows/organize_approved.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Run script
-        run: node .github/scripts/organize_approved.sh
+        run: sh .github/scripts/organize_approved.sh
   
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/organize_approved.yaml
+++ b/.github/workflows/organize_approved.yaml
@@ -21,7 +21,7 @@ jobs:
       
       - name: Run script
         run: node .github/scripts/organize_approved.sh
-
+  
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with: 

--- a/.github/workflows/organize_approved.yaml
+++ b/.github/workflows/organize_approved.yaml
@@ -1,0 +1,28 @@
+name: Ogranize Approved
+
+on: 
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  format-code:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      
+      - name: Run script
+        run: node .github/scripts/organize_approved.sh
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with: 
+          commit_message: 'Organize Approved'

--- a/.github/workflows/organize_approved.yaml
+++ b/.github/workflows/organize_approved.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  format-code:
+  organize-approved:
     runs-on: ubuntu-latest
 
     permissions:
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Run script
-        run: sh .github/scripts/organize_approved.sh
+        run: bash .github/scripts/organize_approved.sh
   
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
# What does this PR do?
Enable github action to automatically move all contributor's documents to the `approved` folder after each merge. 
Excluded files: CONTRIBUTING.md, CODE_OF_CONDUCT.md, README.md
